### PR TITLE
Show undocumented symbols in gray

### DIFF
--- a/manifest.css
+++ b/manifest.css
@@ -39,3 +39,7 @@ ul {
 .symbol, .package {
     text-transform: lowercase;
 }
+
+tr.not-documented>td.docs {
+    color: gray;
+}

--- a/manifest.lisp
+++ b/manifest.lisp
@@ -89,7 +89,7 @@ a true Common Lisp while still working in Allegro's mlisp."
                       (:table
                        (dolist (sym names)
                          (html
-                           (:tr
+                           ((:tr :class (:format "~:[not-documented~;~]" (docs-for sym what)))
                             (:td :class "symbol" (:print (princ-to-string sym)))
                             (:td :class "docs" (:print (or (docs-for sym what) "NO DOCS!")))))))))
 


### PR DESCRIPTION
This change makes "NO DOCS!" not stand out so much vs. the more useful
docstrings.
