### PR TITLE
Small fix

### DIFF
--- a/manifest.asd
+++ b/manifest.asd
@@ -8,6 +8,7 @@
                :toot
                :puri
                :split-sequence
-               :monkeylib-html)
+               :monkeylib-html
+               :cl-fad)
   :components ((:file "packages")
                (:file "manifest" :depends-on ("packages"))))

--- a/manifest.lisp
+++ b/manifest.lisp
@@ -161,7 +161,11 @@ a true Common Lisp while still working in Allegro's mlisp."
 (defun readme-text (package-name)
   (let ((dir (ignore-errors (asdf:system-relative-pathname package-name nil))))
     (when dir
-      (let ((readme (car (directory (merge-pathnames "README.*" dir)))))
+      (let ((readme (find-if #'(lambda (pathname)
+                                 (search "README"
+                                         (file-namestring pathname)
+                                         :test #'equalp))
+                               (cl-fad:list-directory dir))))
         (when readme
          (with-open-file (in readme :if-does-not-exist nil)
            (when in

--- a/manifest.lisp
+++ b/manifest.lisp
@@ -161,11 +161,13 @@ a true Common Lisp while still working in Allegro's mlisp."
 (defun readme-text (package-name)
   (let ((dir (ignore-errors (asdf:system-relative-pathname package-name nil))))
     (when dir
-      (with-open-file (in (merge-pathnames "README" dir) :if-does-not-exist nil)
-        (when in
-          (with-output-to-string (s)
-            (loop for line = (read-line in nil nil)
-               while line do (write-line line s))))))))
+      (let ((readme (car (directory (merge-pathnames "README.*" dir)))))
+        (when readme
+         (with-open-file (in readme :if-does-not-exist nil)
+           (when in
+             (with-output-to-string (s)
+               (loop for line = (read-line in nil nil)
+                     while line do (write-line line s))))))))))
 
 (defun names (package what)
   (sort

--- a/manifest.lisp
+++ b/manifest.lisp
@@ -237,11 +237,13 @@ a true Common Lisp while still working in Allegro's mlisp."
           `(setf (documentation (find-class ',name) t) "WRITE ME!")))))
 
 (defun readme-text (package-name)
-  (with-open-file (in (find-readme package-name) :if-does-not-exist nil)
-    (when in
-      (with-output-to-string (s)
-        (loop for line = (read-line in nil nil)
-           while line do (write-line line s))))))
+  (let ((readme (find-readme package-name)))
+    (when readme
+     (with-open-file (in readme :if-does-not-exist nil)
+       (when in
+         (with-output-to-string (s)
+           (loop for line = (read-line in nil nil)
+                 while line do (write-line line s))))))))
 
 (defun find-readme (package-name)
   (let ((dir (ignore-errors (asdf:system-relative-pathname package-name nil))))


### PR DESCRIPTION
Add a test in `readme-text` to prevent a failure if `find-readme` didn't find a README and thus returns `nil`.
