### PR TITLE
Manifest was depending on undefined behavior

### DIFF
--- a/manifest.lisp
+++ b/manifest.lisp
@@ -276,7 +276,7 @@ a true Common Lisp while still working in Allegro's mlisp."
   (:pluralization (format nil "~aes" what)))
 
 (define-category :condition (symbol what)
-  (:is (and (find-class symbol nil) (subtypep (find-class symbol nil) 'condition)))
+  (:is (and (symbolp symbol) (find-class symbol nil) (subtypep (find-class symbol nil) 'condition)))
   (:docs (documentation (find-class symbol) t)))
 
 (define-category :variable (symbol what)

--- a/manifest.lisp
+++ b/manifest.lisp
@@ -271,7 +271,7 @@ a true Common Lisp while still working in Allegro's mlisp."
   (:docs (documentation symbol 'function)))
 
 (define-category :class (symbol what)
-  (:is (and (find-class symbol nil) (not (is symbol :condition))))
+  (:is (and (symbolp symbol) (find-class symbol nil) (not (is symbol :condition))))
   (:docs (documentation (find-class symbol) t))
   (:pluralization (format nil "~aes" what)))
 


### PR DESCRIPTION
(find-class x) where x isn't a symbol is undefined behavior.
It broke manifest for clasp - a new Common Lisp implementation.